### PR TITLE
PM-29 Shelter table - changed datatype

### DIFF
--- a/database/dataDefinitionQueries.sql
+++ b/database/dataDefinitionQueries.sql
@@ -14,7 +14,7 @@ CREATE TABLE `Shelter` (
  `Address` varchar(100) not null,
  `EmailAddress` varchar(100) not null,
  `Password` varchar(100) not null,
- `PhoneNumber` int not null,
+ `PhoneNumber` varchar(10) not null,
  `Website` varchar(255),
  `LastUpdated` datetime not null,
   PRIMARY KEY (`ShelterID`),


### PR DESCRIPTION
Max int is 2147483647. If a phone number is 9998887777, we get sql error. Also this will prevent missing leading zeros.